### PR TITLE
avformat: librist patch with various fixes

### DIFF
--- a/libavformat/librist.c
+++ b/libavformat/librist.c
@@ -22,6 +22,7 @@
  */
 
 #include "libavutil/avassert.h"
+#include "libavutil/avstring.h"
 #include "libavutil/opt.h"
 #include "libavutil/parseutils.h"
 #include "libavutil/time.h"
@@ -33,9 +34,18 @@
 #include "url.h"
 
 #include <librist/librist.h>
+#include <librist/version.h>
 
 // RIST_MAX_PACKET_SIZE - 28 minimum protocol overhead
 #define MAX_PAYLOAD_SIZE (10000-28)
+
+#define FF_LIBRIST_MAKE_VERSION(major, minor, patch) \
+    ((patch) + ((minor)* 0x100) + ((major) *0x10000))
+#define FF_LIBRIST_VERSION FF_LIBRIST_MAKE_VERSION(LIBRIST_API_VERSION_MAJOR, LIBRIST_API_VERSION_MINOR, LIBRIST_API_VERSION_PATCH)
+#define FF_LIBRIST_VERSION_41 FF_LIBRIST_MAKE_VERSION(4, 1, 0)
+#define FF_LIBRIST_VERSION_42 FF_LIBRIST_MAKE_VERSION(4, 2, 0)
+
+#define FF_LIBRIST_FIFO_DEFAULT_SHIFT 13
 
 typedef struct RISTContext {
     const AVClass *class;
@@ -45,6 +55,8 @@ typedef struct RISTContext {
     int packet_size;
     int log_level;
     int encryption;
+    int fifo_shift;
+    bool overrun_nonfatal;
     char *secret;
 
     struct rist_logging_settings logging_settings;
@@ -63,6 +75,8 @@ static const AVOption librist_options[] = {
     { "main",        NULL,              0,                   AV_OPT_TYPE_CONST, {.i64=RIST_PROFILE_MAIN},     0, 0, .flags = D|E, "profile" },
     { "advanced",    NULL,              0,                   AV_OPT_TYPE_CONST, {.i64=RIST_PROFILE_ADVANCED}, 0, 0, .flags = D|E, "profile" },
     { "buffer_size", "set buffer_size in ms", OFFSET(buffer_size), AV_OPT_TYPE_INT, {.i64=0},                 0, 30000, .flags = D|E },
+    { "fifo_size", "Set libRIST fifo buffer size, applied as: buffer_size=2^fifo_size", OFFSET(fifo_shift), AV_OPT_TYPE_INT, {.i64=FF_LIBRIST_FIFO_DEFAULT_SHIFT}, 10, 63, .flags = D|E },
+    { "overrun_nonfatal", "survive in case of libRIST receiving circular buffer overrun", OFFSET(overrun_nonfatal), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1,    D },
     { "pkt_size",    "set packet size", OFFSET(packet_size), AV_OPT_TYPE_INT,   {.i64=1316},                  1, MAX_PAYLOAD_SIZE,    .flags = D|E },
     { "log_level",   "set loglevel",    OFFSET(log_level),   AV_OPT_TYPE_INT,   {.i64=RIST_LOG_INFO},        -1, INT_MAX, .flags = D|E },
     { "secret", "set encryption secret",OFFSET(secret),      AV_OPT_TYPE_STRING,{.str=NULL},                  0, 0,       .flags = D|E },
@@ -123,6 +137,8 @@ static int librist_open(URLContext *h, const char *uri, int flags)
     if ((flags & AVIO_FLAG_READ_WRITE) == AVIO_FLAG_READ_WRITE)
         return AVERROR(EINVAL);
 
+    s->logging_settings =
+	    (struct rist_logging_settings)LOGGING_SETTINGS_INITIALIZER;
     ret = rist_logging_set(&logging_settings, s->log_level, log_cb, h, NULL, NULL);
     if (ret < 0)
         return risterr2ret(ret);
@@ -145,9 +161,26 @@ static int librist_open(URLContext *h, const char *uri, int flags)
     if (ret < 0)
         goto err;
 
+#if FF_LIBRIST_VERSION < FF_LIBRIST_VERSION_41
     ret = rist_parse_address(uri, (const struct rist_peer_config **)&peer_config);
+#else
+    ret = rist_parse_address2(uri, &peer_config);
+#endif
     if (ret < 0)
         goto err;
+
+    //Prior to 4.2.0 there was a bug in libRIST which made this call always fail.
+#if FF_LIBRIST_VERSION >= FF_LIBRIST_VERSION_42
+    if (flags & AVIO_FLAG_READ) {
+        ret = rist_receiver_set_output_fifo_size(s->ctx, 2 << s->fifo_shift);
+        if (ret != 0)
+            goto err;
+    }
+#else
+    if (s->fifo_buffer_size != FF_LIBRIST_FIFO_DEFAULT) {
+        av_log(h, AV_LOG_ERROR, "libRIST prior to 0.2.7 has a bug which fails setting the fifo buffer size");
+    }
+#endif
 
     if (((s->encryption == 128 || s->encryption == 256) && !s->secret) ||
         ((peer_config->key_size == 128 || peer_config->key_size == 256) && !peer_config->secret[0])) {
@@ -186,10 +219,16 @@ err:
 static int librist_read(URLContext *h, uint8_t *buf, int size)
 {
     RISTContext *s = h->priv_data;
-    const struct rist_data_block *data_block;
     int ret;
 
+#if FF_LIBRIST_VERSION < FF_LIBRIST_VERSION_41
+    const struct rist_data_block *data_block;
     ret = rist_receiver_data_read(s->ctx, &data_block, POLLING_TIME);
+#else
+    struct rist_data_block *data_block;
+    ret = rist_receiver_data_read2(s->ctx, &data_block, POLLING_TIME);
+#endif
+
     if (ret < 0)
         return risterr2ret(ret);
 
@@ -197,14 +236,37 @@ static int librist_read(URLContext *h, uint8_t *buf, int size)
         return AVERROR(EAGAIN);
 
     if (data_block->payload_len > MAX_PAYLOAD_SIZE) {
+#if FF_LIBRIST_VERSION < FF_LIBRIST_VERSION_41
         rist_receiver_data_block_free((struct rist_data_block**)&data_block);
+#else
+        rist_receiver_data_block_free2(&data_block);
+#endif
         return AVERROR_EXTERNAL;
     }
 
+#if FF_LIBRIST_VERSION >= FF_LIBRIST_VERSION_42
+    if (data_block->flags & RIST_DATA_FLAGS_OVERFLOW == RIST_DATA_FLAGS_OVERFLOW) {
+        if (!s->overrun_nonfatal) {
+            av_log(h, AV_LOG_ERROR, "Fifo buffer overrun. "
+                    "To avoid, increase fifo_size URL option. "
+                    "To survive in such case, use overrun_nonfatal option\n");
+            size = AVERROR(EIO);
+            goto out_free;
+        } else {
+            av_log(h, AV_LOG_WARNING, "Fifo buffer buffer overrun. "
+                    "Surviving due to overrun_nonfatal option\n");
+        }
+    }
+#endif
+
     size = data_block->payload_len;
     memcpy(buf, data_block->payload, size);
+out_free:
+#if FF_LIBRIST_VERSION < FF_LIBRIST_VERSION_41
     rist_receiver_data_block_free((struct rist_data_block**)&data_block);
-
+#else
+    rist_receiver_data_block_free2(&data_block);
+#endif
     return size;
 }
 


### PR DESCRIPTION
### Description
The librist patch consists in these 3 commits which haven't been backported to FFmpeg 4.4 :
     [1] avformat/internal: Move ff_read_line_to_bprint_overwrite to avio_internal.h
     https://github.com/FFmpeg/FFmpeg/commit/fd101c9c3bcdeb2d74274aaeaa968fe8ead3622d#diff-bc82665cda5e82b13bcd3e1ee74d820952d80acba839ac46ffed3f0785644200
     [2] avformat/librist: replace deprecated functions
     https://github.com/FFmpeg/FFmpeg/commit/5274f2f7f8c5e40d18b84055fbb232752bd24f2f#diff-bc82665cda5e82b13bcd3e1ee74d820952d80acba839ac46ffed3f0785644200
     [3] avformat/librist: correctly initialize logging_settings
     https://github.com/FFmpeg/FFmpeg/commit/9b15f43cf8c7976fba115da686a990377f7b5ab9
The following is an important patch submitted by librist devs, but not yet merged into FFmpeg master.
It is required to fix Media Source issues.
     [4] avformat/librist: allow setting fifo size and fail on overflow.
     http://ffmpeg.org/pipermail/ffmpeg-devel/2021-November/287914.html

### Motivation and Context
Get a working implementation of rist protocol.
The patch is required to have rist working on windows Media Source (rist streaming is working though).

### How Has This Been Tested?
Patch used in obs-deps. Tested and working.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
